### PR TITLE
:ash_admin was missing from the .formatter.exs import_deps.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 [
   import_deps: [
+    :ash_admin,
     :ash_postgres,
     :ash_authentication_phoenix,
     :ash_authentication,

--- a/lib/kindkaboom/accounts.ex
+++ b/lib/kindkaboom/accounts.ex
@@ -2,11 +2,11 @@ defmodule Kindkaboom.Accounts do
   use Ash.Domain, otp_app: :kindkaboom, extensions: [AshAdmin.Domain]
 
   admin do
-    show?(true)
+    show? true
   end
 
   resources do
-    resource Kindkaboom.Accounts.Token
     resource Kindkaboom.Accounts.User
+    resource Kindkaboom.Accounts.Token
   end
 end

--- a/lib/kindkaboom_web/router.ex
+++ b/lib/kindkaboom_web/router.ex
@@ -93,7 +93,7 @@ defmodule KindkaboomWeb.Router do
     scope "/admin" do
       pipe_through :browser
 
-      ash_admin("/")
+      ash_admin "/"
     end
   end
 end


### PR DESCRIPTION
Added :ash_admin to the .formatter.exs import_deps and fixed the parens in the router.ex and accounts.ex

closes #11